### PR TITLE
change listOptions type to internal version of `meta.ListOptions`

### DIFF
--- a/constants/constants.go
+++ b/constants/constants.go
@@ -27,8 +27,7 @@ const (
 	SearchLabelNamespaces = "search.clusterpedia.io/namespaces"
 	SearchLabelOrderBy    = "search.clusterpedia.io/orderby"
 
-	// TODO: clusterpedia will change the label to search.clusterpedia.io/limit
-	SearchLabelSize   = "search.clusterpedia.io/size"
+	SearchLabelLimit  = "search.clusterpedia.io/limit"
 	SearchLabelOffset = "search.clusterpedia.io/offset"
 
 	OrderByDesc = "_desc"

--- a/tools/builder/options_test.go
+++ b/tools/builder/options_test.go
@@ -28,36 +28,49 @@ func TestListOptions(t *testing.T) {
 		expectLabelSelector string
 	}{
 		{
-			ListOptionsBuilder().Clusters("cluster-01").Options(),
-			"search.clusterpedia.io/clusters in (cluster-01)",
+			ListOptionsBuilder().Clusters("aaa").Clusters("bbb", "ccc").Options(),
+			"search.clusterpedia.io/clusters in (aaa,bbb,ccc)",
 		},
 		{
-			ListOptionsBuilder().Clusters("cluster-01", "cluster-02", "ABC").Options(),
-			"search.clusterpedia.io/clusters in (ABC,cluster-01,cluster-02)",
+			ListOptionsBuilder().Clusters("aaa", "bbb", "ccc").
+				Namespaces("ddd").Options(),
+			"search.clusterpedia.io/clusters in (aaa,bbb,ccc),search.clusterpedia.io/namespaces in (ddd)",
 		},
 		{
-			ListOptionsBuilder().Clusters("cluster-01", "cluster-02").
-				Namespaces("default", "kube-system").Options(),
-			"search.clusterpedia.io/clusters in (cluster-01,cluster-02),search.clusterpedia.io/namespaces in (default,kube-system)",
+			ListOptionsBuilder().Clusters("aaa").
+				Namespaces("bbb", "ccc").
+				Namespaces("ddd").Options(),
+			"search.clusterpedia.io/clusters in (aaa),search.clusterpedia.io/namespaces in (bbb,ccc,ddd)",
 		},
 		{
-			ListOptionsBuilder().Clusters("cluster-01").
-				Namespaces("kube-system").Offset(0).Size(5).Options(),
-			"search.clusterpedia.io/clusters in (cluster-01),search.clusterpedia.io/namespaces in (kube-system),search.clusterpedia.io/offset=0,search.clusterpedia.io/size=5",
+			ListOptionsBuilder().Clusters("aaa").Clusters("bbbb").
+				Namespaces("ccc").
+				Offset(0).Size(5).Options(),
+			"search.clusterpedia.io/clusters in (aaa,bbbb),search.clusterpedia.io/limit=5,search.clusterpedia.io/namespaces in (ccc),search.clusterpedia.io/offset=0",
 		},
 		{
-			ListOptionsBuilder().Clusters("cluster-01").
-				Namespaces("kube-system").
+			ListOptionsBuilder().Clusters("aaa").Clusters("bbbb").
+				Namespaces("ccc").
+				Offset(0).Size(5).
+				Offset(10).Size(10).Options(),
+			"search.clusterpedia.io/clusters in (aaa,bbbb),search.clusterpedia.io/limit=10,search.clusterpedia.io/namespaces in (ccc),search.clusterpedia.io/offset=10",
+		},
+		{
+			ListOptionsBuilder().Clusters("aaa").
+				Namespaces("bbb").
 				Offset(10).Size(5).
-				OrderBy(Order{"dsad", false}).Options(),
-			"search.clusterpedia.io/clusters in (cluster-01),search.clusterpedia.io/namespaces in (kube-system),search.clusterpedia.io/offset=10,search.clusterpedia.io/offset=dsad,search.clusterpedia.io/size=5",
+				OrderBy("dsad", true).
+				OrderBy("basd").Options(),
+			"search.clusterpedia.io/clusters in (aaa),search.clusterpedia.io/limit=5,search.clusterpedia.io/namespaces in (bbb),search.clusterpedia.io/offset=10,search.clusterpedia.io/orderby in (basd,dsad_desc)",
 		},
 	}
+
 	for _, test := range testCase {
 		t.Run("", func(t *testing.T) {
 			if test.opt.LabelSelector != test.expectLabelSelector {
 				t.Errorf("Unexpect label selector: %s", test.opt.LabelSelector)
 			}
+
 		})
 	}
 }

--- a/tools/builder/selector.go
+++ b/tools/builder/selector.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2021 clusterpedia Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package builder
+
+import (
+	"sort"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
+)
+
+type simpleSelector []labels.Requirement
+
+func NewSelector() labels.Selector {
+	return simpleSelector(nil)
+}
+
+func (s simpleSelector) Matches(_ labels.Labels) bool                               { return false }
+func (s simpleSelector) Empty() bool                                                { return false }
+func (s simpleSelector) Requirements() (labels.Requirements, bool)                  { return nil, false }
+func (s simpleSelector) DeepCopySelector() labels.Selector                          { return s }
+func (s simpleSelector) RequiresExactMatch(label string) (value string, found bool) { return "", false }
+
+func (s simpleSelector) Add(reqs ...labels.Requirement) labels.Selector {
+	for ix, requirement := range reqs {
+		if val, found := s.exists(requirement.Key()); found {
+			s = s.remove(requirement.Key())
+
+			values := requirement.Values().List()
+			if requirement.Operator() == selection.In {
+				values = append(values, val...)
+				nr, _ := labels.NewRequirement(requirement.Key(), requirement.Operator(),
+					append([]string(nil), values...))
+
+				reqs[ix] = *nr
+			}
+		}
+	}
+
+	ret := make(simpleSelector, 0, len(s)+len(reqs))
+	ret = append(ret, s...)
+	ret = append(ret, reqs...)
+	sort.Sort(labels.ByKey(ret))
+	return ret
+}
+
+func (s simpleSelector) String() string {
+	var reqs []string
+	for ix := range s {
+		reqs = append(reqs, s[ix].String())
+	}
+	return strings.Join(reqs, ",")
+}
+
+func (s simpleSelector) exists(label string) (value []string, found bool) {
+	for _, v := range s {
+		if v.Key() == label {
+			return v.Values().List(), true
+		}
+	}
+	return nil, false
+}
+
+func (s simpleSelector) remove(key string) simpleSelector {
+	for i, v := range s {
+		if v.Key() == key {
+			s = append(s[:i], s[i+1:]...)
+			return s
+		}
+	}
+	return s
+}


### PR DESCRIPTION
fixed: https://github.com/clusterpedia-io/client-go/issues/2

change listOptions type to internal version of `meta.ListOptions`