### PR TITLE
move pedia.clusterpedia.io/v1alpha1 to clusterpedia.io/v1beta1

### DIFF
--- a/constants/constants.go
+++ b/constants/constants.go
@@ -18,7 +18,7 @@ package constants
 
 const (
 	// ClusterPediaAPIPath is the extra path of apiserver
-	ClusterPediaAPIPath = "/apis/clusterpedia.io/v1alpha1/resources"
+	ClusterPediaAPIPath = "/apis/clusterpedia.io/v1beta1/resources"
 	// ClusterAPIPath for a specific cluster
 	ClusterAPIPath = "/clusters/"
 


### PR DESCRIPTION
fix the clusterpedia apiserver path `apis/clusterpedia.io/v1beta1/resources`.